### PR TITLE
opsctl: copy kvm/v3 to kvm/v4

### DIFF
--- a/service/controller/kvm/v4/error.go
+++ b/service/controller/kvm/v4/error.go
@@ -1,0 +1,17 @@
+package v3
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v4/key/error.go
+++ b/service/controller/kvm/v4/key/error.go
@@ -1,0 +1,17 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var emptyValueError = microerror.New("empty value")
+
+// IsEmptyValueError asserts emptyValueError.
+func IsEmptyValueError(err error) bool {
+	return microerror.Cause(err) == emptyValueError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v4/key/key.go
+++ b/service/controller/kvm/v4/key/key.go
@@ -1,0 +1,37 @@
+package key
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+)
+
+// ClusterID extracts clusterID from v1alpha1.KVMClusterConfig.
+func ClusterID(customObject v1alpha1.KVMClusterConfig) string {
+	return customObject.Spec.Guest.ClusterGuestConfig.ID
+}
+
+// ToClusterGuestConfig extracts ClusterGuestConfig from KVMClusterConfig.
+func ToClusterGuestConfig(kvmClusterConfig v1alpha1.KVMClusterConfig) v1alpha1.ClusterGuestConfig {
+	return kvmClusterConfig.Spec.Guest.ClusterGuestConfig
+}
+
+// ToCustomObject converts value to v1alpha1.KVMClusterConfig and returns it or
+// error if type does not match.
+func ToCustomObject(v interface{}) (v1alpha1.KVMClusterConfig, error) {
+	customObjectPointer, ok := v.(*v1alpha1.KVMClusterConfig)
+	if !ok {
+		return v1alpha1.KVMClusterConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.KVMClusterConfig{}, v)
+	}
+
+	if customObjectPointer == nil {
+		return v1alpha1.KVMClusterConfig{}, microerror.Maskf(emptyValueError,
+			"empty value cannot be converted to CustomObject")
+	}
+
+	return *customObjectPointer, nil
+}
+
+// VersionBundleVersion extracts version bundle version from KVMClusterConfig.
+func VersionBundleVersion(kvmClusterConfig v1alpha1.KVMClusterConfig) string {
+	return kvmClusterConfig.Spec.VersionBundle.Version
+}

--- a/service/controller/kvm/v4/key/key_test.go
+++ b/service/controller/kvm/v4/key/key_test.go
@@ -1,0 +1,140 @@
+package key
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+)
+
+func Test_ClusterID(t *testing.T) {
+	testCases := []struct {
+		description  string
+		customObject v1alpha1.KVMClusterConfig
+		expectedID   string
+	}{
+		{
+			description:  "empty value KVMClusterConfig produces empty ID",
+			customObject: v1alpha1.KVMClusterConfig{},
+			expectedID:   "",
+		},
+		{
+			description: "present ID value returned as ClusterID",
+			customObject: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID: "cluster-1",
+						},
+					},
+				},
+			},
+			expectedID: "cluster-1",
+		},
+		{
+			description: "only present ID value returned as ClusterID",
+			customObject: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID:   "cluster-123",
+							Name: "First cluster",
+						},
+					},
+				},
+			},
+			expectedID: "cluster-123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			clusterID := ClusterID(tc.customObject)
+			if clusterID != tc.expectedID {
+				t.Fatalf("ClusterID %s doesn't match. expected: %s", clusterID, tc.expectedID)
+			}
+		})
+	}
+}
+
+func Test_ToCustomObject(t *testing.T) {
+	var emptyKVMClusterConfigPtr *v1alpha1.KVMClusterConfig
+
+	testCases := []struct {
+		description          string
+		inputObject          interface{}
+		expectedCustomObject v1alpha1.KVMClusterConfig
+		expectedError        error
+	}{
+		{
+			description:          "reference to empty value KVMClusterConfig returns empty KVMClusterConfig",
+			inputObject:          &v1alpha1.KVMClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        nil,
+		},
+		{
+			description: "verify that internal KVMClusterConfig fields are returned as well",
+			inputObject: &v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID:   "cluster-1",
+							Name: "My own snowflake cluster",
+						},
+					},
+				},
+			},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{
+				Spec: v1alpha1.KVMClusterConfigSpec{
+					Guest: v1alpha1.KVMClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID:   "cluster-1",
+							Name: "My own snowflake cluster",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			description:          "nil pointer to KVMClusterConfig must return emptyValueError",
+			inputObject:          emptyKVMClusterConfigPtr,
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        emptyValueError,
+		},
+		{
+			description:          "non-pointer value of KVMClusterConfig must return wrontTypeError",
+			inputObject:          v1alpha1.KVMClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+		{
+			description:          "wrong type must return wrongTypeError",
+			inputObject:          &v1alpha1.AzureClusterConfig{},
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+		{
+			description:          "nil interface{} must return wrongTypeError",
+			inputObject:          nil,
+			expectedCustomObject: v1alpha1.KVMClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			customObject, err := ToCustomObject(tc.inputObject)
+			if microerror.Cause(err) != tc.expectedError {
+				t.Errorf("Received error %#v doesn't match expected %#v",
+					err, tc.expectedError)
+			}
+
+			if !reflect.DeepEqual(customObject, tc.expectedCustomObject) {
+				t.Fatalf("customObject %#v doesn't match expected %#v",
+					customObject, tc.expectedCustomObject)
+			}
+		})
+	}
+}

--- a/service/controller/kvm/v4/resource/kvmconfig/create.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/create.go
@@ -1,0 +1,12 @@
+package kvmconfig
+
+import (
+	"context"
+)
+
+// ApplyCreateChange takes observed custom object and create portion of the
+// Patch provided by NewUpdatePatch or NewDeletePatch. It creates KVMConfig if
+// needed.
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}

--- a/service/controller/kvm/v4/resource/kvmconfig/create_test.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/create_test.go
@@ -1,0 +1,1 @@
+package kvmconfig

--- a/service/controller/kvm/v4/resource/kvmconfig/current.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/current.go
@@ -1,0 +1,12 @@
+package kvmconfig
+
+import (
+	"context"
+)
+
+// GetCurrentState takes observed custom object as an input and based on that
+// information looks for current state of KVMConfig and returns it. Return
+// value is of type *v1alpha1.KVMConfig.
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/kvm/v4/resource/kvmconfig/delete.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/delete.go
@@ -1,0 +1,23 @@
+package kvmconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+// ApplyDeleteChange takes observed custom object and delete portion of the
+// Patch provided by NewUpdatePatch and NewDeletePatch. It deletes KVMConfig if
+// needed.
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+// NewDeletePatch is called upon observed custom object deletion. It receives
+// the deleted custom object, the current state as provided by GetCurrentState
+// and the desired state as provided by GetDesiredState. NewDeletePatch
+// analyses the current and desired state and returns the patch to be applied by
+// Create, Delete, and Update functions.
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
+}

--- a/service/controller/kvm/v4/resource/kvmconfig/delete_test.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/delete_test.go
@@ -1,0 +1,1 @@
+package kvmconfig

--- a/service/controller/kvm/v4/resource/kvmconfig/desired.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/desired.go
@@ -1,0 +1,11 @@
+package kvmconfig
+
+import (
+	"context"
+)
+
+// GetDesiredState takes observed (during create, delete and update events)
+// custom object as an input and returns computed desired state for it.
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/kvm/v4/resource/kvmconfig/desired_test.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/desired_test.go
@@ -1,0 +1,1 @@
+package kvmconfig

--- a/service/controller/kvm/v4/resource/kvmconfig/error.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/error.go
@@ -1,0 +1,17 @@
+package kvmconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/kvm/v4/resource/kvmconfig/resource.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/resource.go
@@ -1,0 +1,61 @@
+package kvmconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "kvmconfigv2"
+)
+
+// Config represents the configuration used to create a new cloud config resource.
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the cloud config resource.
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured cloud config resource.
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newService, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toKvmConfig(v interface{}) (*v1alpha1.KVMConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	kvmConfig, ok := v.(*v1alpha1.KVMConfig)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.KVMConfig{}, v)
+	}
+
+	return kvmConfig, nil
+}

--- a/service/controller/kvm/v4/resource/kvmconfig/update.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/update.go
@@ -1,0 +1,20 @@
+package kvmconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+// ApplyUpdateChange takes observed custom object and update portion of the
+// Patch provided by NewUpdatePatch or NewDeletePatch. This updates KVMConfig
+// when needed.
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+// NewUpdatePatch computes appropriate Patch based on difference in current
+// state and desired state.
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
+}

--- a/service/controller/kvm/v4/resource/kvmconfig/update_test.go
+++ b/service/controller/kvm/v4/resource/kvmconfig/update_test.go
@@ -1,0 +1,1 @@
+package kvmconfig

--- a/service/controller/kvm/v4/resource_set.go
+++ b/service/controller/kvm/v4/resource_set.go
@@ -1,0 +1,226 @@
+package v3
+
+import (
+	"context"
+
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/apprclient"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/test-operator/pkg/cluster"
+	"github.com/giantswarm/test-operator/pkg/v3/guestcluster"
+	"github.com/giantswarm/test-operator/pkg/v3/resource/chart"
+	"github.com/giantswarm/test-operator/pkg/v3/resource/encryptionkey"
+	"github.com/giantswarm/test-operator/service/controller/kvm/v3/key"
+	"github.com/giantswarm/test-operator/service/controller/kvm/v3/resource/kvmconfig"
+)
+
+const (
+	// ResourceRetries presents number of retries for failed Resource
+	// operation before giving up.
+	ResourceRetries uint64 = 3
+)
+
+// ResourceSetConfig contains necessary dependencies and settings for
+// KVMClusterConfig controller ResourceSet configuration.
+type ResourceSetConfig struct {
+	ApprClient        *apprclient.Client
+	BaseClusterConfig *cluster.Config
+	CertSearcher      certs.Interface
+	Fs                afero.Fs
+	G8sClient         versioned.Interface
+	Guest             guestcluster.Interface
+	K8sClient         kubernetes.Interface
+	Logger            micrologger.Logger
+
+	HandledVersionBundles []string
+	ProjectName           string
+}
+
+// NewResourceSet returns a configured KVMClusterConfig controller ResourceSet.
+func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.ProjectName must not be empty")
+	}
+
+	var encryptionKeyResource controller.Resource
+	{
+		c := encryptionkey.Config{
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+		}
+
+		ops, err := encryptionkey.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		encryptionKeyResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var kvmConfigResource controller.Resource
+	{
+		c := kvmconfig.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := kvmconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		kvmConfigResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var guestClusterService *guestcluster.Service
+	{
+		c := guestcluster.Config{
+			CertsSearcher: config.CertSearcher,
+			Logger:        config.Logger,
+		}
+
+		guestClusterService, err = guestcluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var chartResource controller.Resource
+	{
+		c := chart.Config{
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			Guest:                    guestClusterService,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+		}
+
+		ops, err := chart.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		chartResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		// Put encryptionKeyResource first because it executes faster than
+		// kvmConfigResource and could introduce dependency during cluster
+		// creation.
+		encryptionKeyResource,
+		kvmConfigResource,
+		chartResource,
+	}
+
+	// Wrap resources with retry and metrics.
+	{
+		retryWrapConfig := retryresource.WrapConfig{}
+
+		retryWrapConfig.BackOffFactory = func() backoff.BackOff { return backoff.WithMaxTries(backoff.NewExponentialBackOff(), ResourceRetries) }
+		retryWrapConfig.Logger = config.Logger
+
+		resources, err = retryresource.Wrap(resources, retryWrapConfig)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		metricsWrapConfig := metricsresource.WrapConfig{}
+
+		metricsWrapConfig.Name = config.ProjectName
+
+		resources, err = metricsresource.Wrap(resources, metricsWrapConfig)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		return ctx, nil
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		kvmClusterConfig, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(kvmClusterConfig) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}
+
+func toClusterGuestConfig(obj interface{}) (v1alpha1.ClusterGuestConfig, error) {
+	kvmClusterConfig, err := key.ToCustomObject(obj)
+	if err != nil {
+		return v1alpha1.ClusterGuestConfig{}, microerror.Mask(err)
+	}
+
+	return key.ToClusterGuestConfig(kvmClusterConfig), nil
+}
+
+func toCRUDResource(logger micrologger.Logger, ops controller.CRUDResourceOps) (*controller.CRUDResource, error) {
+	c := controller.CRUDResourceConfig{
+		Logger: logger,
+		Ops:    ops,
+	}
+
+	r, err := controller.NewCRUDResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/kvm/v4/version_bundle.go
+++ b/service/controller/kvm/v4/version_bundle.go
@@ -1,0 +1,32 @@
+package v3
+
+import (
+	"time"
+
+	"github.com/giantswarm/versionbundle"
+)
+
+func VersionBundle() versionbundle.Bundle {
+	return versionbundle.Bundle{
+		Changelogs: []versionbundle.Changelog{
+			{
+				Component:   "test-operator",
+				Description: "Installed chart-operator in kube-system namespace.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "test-operator",
+				Description: "Removed misleading component reference to kvm-operator.",
+				Kind:        versionbundle.KindFixed,
+			},
+		},
+		Components:   []versionbundle.Component{},
+		Dependencies: []versionbundle.Dependency{},
+		Deprecated:   false,
+		Name:         "test-operator",
+		Provider:     "kvm",
+		Time:         time.Date(2018, time.April, 26, 12, 00, 0, 0, time.UTC),
+		Version:      "0.3.0",
+		WIP:          true,
+	}
+}


### PR DESCRIPTION
This PR got created by `opsctl` in order to automate the creation of a new WIP version bundle. This specific PR is to copy the latest resource package only.