### PR TITLE
opsctl: copy aws/v3 to aws/v4

### DIFF
--- a/service/controller/aws/v4/error.go
+++ b/service/controller/aws/v4/error.go
@@ -1,0 +1,10 @@
+package v3
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/aws/v4/key/error.go
+++ b/service/controller/aws/v4/key/error.go
@@ -1,0 +1,17 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var emptyValueError = microerror.New("empty value")
+
+// IsEmptyValueError asserts emptyValueError.
+func IsEmptyValueError(err error) bool {
+	return microerror.Cause(err) == emptyValueError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/aws/v4/key/key.go
+++ b/service/controller/aws/v4/key/key.go
@@ -1,0 +1,31 @@
+package key
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+)
+
+// ClusterGuestConfig extracts ClusterGuestConfig from AWSClusterConfig.
+func ClusterGuestConfig(awsClusterConfig v1alpha1.AWSClusterConfig) v1alpha1.ClusterGuestConfig {
+	return awsClusterConfig.Spec.Guest.ClusterGuestConfig
+}
+
+// ToCustomObject converts value to v1alpha1.AWSClusterConfig and returns it or
+// error if type does not match.
+func ToCustomObject(v interface{}) (v1alpha1.AWSClusterConfig, error) {
+	customObjectPointer, ok := v.(*v1alpha1.AWSClusterConfig)
+	if !ok {
+		return v1alpha1.AWSClusterConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.AWSClusterConfig{}, v)
+	}
+
+	if customObjectPointer == nil {
+		return v1alpha1.AWSClusterConfig{}, microerror.Maskf(emptyValueError, "empty value cannot be converted to CustomObject")
+	}
+
+	return *customObjectPointer, nil
+}
+
+// VersionBundleVersion extracts version bundle version from AWSClusterConfig.
+func VersionBundleVersion(awsClusterConfig v1alpha1.AWSClusterConfig) string {
+	return awsClusterConfig.Spec.VersionBundle.Version
+}

--- a/service/controller/aws/v4/key/key_test.go
+++ b/service/controller/aws/v4/key/key_test.go
@@ -1,0 +1,90 @@
+package key
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+)
+
+func Test_ToCustomObject(t *testing.T) {
+	var emptyAWSClusterConfigPtr *v1alpha1.AWSClusterConfig
+
+	testCases := []struct {
+		description          string
+		inputObject          interface{}
+		expectedCustomObject v1alpha1.AWSClusterConfig
+		expectedError        error
+	}{
+		{
+			description:          "reference to empty value AWSClusterConfig returns empty AWSClusterConfig",
+			inputObject:          &v1alpha1.AWSClusterConfig{},
+			expectedCustomObject: v1alpha1.AWSClusterConfig{},
+			expectedError:        nil,
+		},
+		{
+			description: "verify that internal AWSClusterConfig fields are returned as well",
+			inputObject: &v1alpha1.AWSClusterConfig{
+				Spec: v1alpha1.AWSClusterConfigSpec{
+					Guest: v1alpha1.AWSClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID:   "cluster-1",
+							Name: "My own snowflake cluster",
+						},
+					},
+				},
+			},
+			expectedCustomObject: v1alpha1.AWSClusterConfig{
+				Spec: v1alpha1.AWSClusterConfigSpec{
+					Guest: v1alpha1.AWSClusterConfigSpecGuest{
+						ClusterGuestConfig: v1alpha1.ClusterGuestConfig{
+							ID:   "cluster-1",
+							Name: "My own snowflake cluster",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			description:          "nil pointer to AWSClusterConfig must return emptyValueError",
+			inputObject:          emptyAWSClusterConfigPtr,
+			expectedCustomObject: v1alpha1.AWSClusterConfig{},
+			expectedError:        emptyValueError,
+		},
+		{
+			description:          "non-pointer value of AWSClusterConfig must return wrongTypeError",
+			inputObject:          v1alpha1.AWSClusterConfig{},
+			expectedCustomObject: v1alpha1.AWSClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+		{
+			description:          "wrong type must return wrongTypeError",
+			inputObject:          &v1alpha1.AzureClusterConfig{},
+			expectedCustomObject: v1alpha1.AWSClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+		{
+			description:          "nil interface{} must return wrongTypeError",
+			inputObject:          nil,
+			expectedCustomObject: v1alpha1.AWSClusterConfig{},
+			expectedError:        wrongTypeError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			customObject, err := ToCustomObject(tc.inputObject)
+			if microerror.Cause(err) != tc.expectedError {
+				t.Errorf("Received error %#v doesn't match expected %#v",
+					err, tc.expectedError)
+			}
+
+			if !reflect.DeepEqual(customObject, tc.expectedCustomObject) {
+				t.Fatalf("customObject %#v doesn't match expected %#v",
+					customObject, tc.expectedCustomObject)
+			}
+		})
+	}
+}

--- a/service/controller/aws/v4/resource/awsconfig/create.go
+++ b/service/controller/aws/v4/resource/awsconfig/create.go
@@ -1,0 +1,12 @@
+package awsconfig
+
+import (
+	"context"
+)
+
+// ApplyCreateChange takes observed custom object and create portion of the
+// Patch provided by NewUpdatePatch or NewDeletePatch. It creates AWSConfig if
+// needed.
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}

--- a/service/controller/aws/v4/resource/awsconfig/create_test.go
+++ b/service/controller/aws/v4/resource/awsconfig/create_test.go
@@ -1,0 +1,1 @@
+package awsconfig

--- a/service/controller/aws/v4/resource/awsconfig/current.go
+++ b/service/controller/aws/v4/resource/awsconfig/current.go
@@ -1,0 +1,12 @@
+package awsconfig
+
+import (
+	"context"
+)
+
+// GetCurrentState takes observed custom object as an input and based on that
+// information looks for current state of AWSConfig and returns it. Return
+// value is of type *v1alpha1.AWSConfig.
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/aws/v4/resource/awsconfig/delete.go
+++ b/service/controller/aws/v4/resource/awsconfig/delete.go
@@ -1,0 +1,23 @@
+package awsconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+// ApplyDeleteChange takes observed custom object and delete portion of the
+// Patch provided by NewUpdatePatch and NewDeletePatch. It deletes AWSConfig if
+// needed.
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+// NewDeletePatch is called upon observed custom object deletion. It receives
+// the deleted custom object, the current state as provided by GetCurrentState
+// and the desired state as provided by GetDesiredState. NewDeletePatch
+// analyses the current and desired state and returns the patch to be applied by
+// Create, Delete, and Update functions.
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
+}

--- a/service/controller/aws/v4/resource/awsconfig/delete_test.go
+++ b/service/controller/aws/v4/resource/awsconfig/delete_test.go
@@ -1,0 +1,1 @@
+package awsconfig

--- a/service/controller/aws/v4/resource/awsconfig/desired.go
+++ b/service/controller/aws/v4/resource/awsconfig/desired.go
@@ -1,0 +1,11 @@
+package awsconfig
+
+import (
+	"context"
+)
+
+// GetDesiredState takes observed (during create, delete and update events)
+// custom object as an input and returns computed desired state for it.
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/aws/v4/resource/awsconfig/desired_test.go
+++ b/service/controller/aws/v4/resource/awsconfig/desired_test.go
@@ -1,0 +1,1 @@
+package awsconfig

--- a/service/controller/aws/v4/resource/awsconfig/error.go
+++ b/service/controller/aws/v4/resource/awsconfig/error.go
@@ -1,0 +1,17 @@
+package awsconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/aws/v4/resource/awsconfig/resource.go
+++ b/service/controller/aws/v4/resource/awsconfig/resource.go
@@ -1,0 +1,60 @@
+package awsconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "awsconfigv3"
+)
+
+// Config represents the configuration used to create a new cloud config resource.
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the cloud config resource.
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured cloud config resource.
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+// Name returns name of the Resource.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toAwsConfig(v interface{}) (*v1alpha1.AWSConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	awsConfig, ok := v.(*v1alpha1.AWSConfig)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.AWSConfig{}, v)
+	}
+
+	return awsConfig, nil
+}

--- a/service/controller/aws/v4/resource/awsconfig/update.go
+++ b/service/controller/aws/v4/resource/awsconfig/update.go
@@ -1,0 +1,20 @@
+package awsconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+// ApplyUpdateChange takes observed custom object and update portion of the
+// Patch provided by NewUpdatePatch or NewDeletePatch. This updates AWSConfig
+// when needed.
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+// NewUpdatePatch computes appropriate Patch based on difference in current
+// state and desired state.
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
+}

--- a/service/controller/aws/v4/resource/awsconfig/update_test.go
+++ b/service/controller/aws/v4/resource/awsconfig/update_test.go
@@ -1,0 +1,1 @@
+package awsconfig

--- a/service/controller/aws/v4/resource_set.go
+++ b/service/controller/aws/v4/resource_set.go
@@ -1,0 +1,226 @@
+package v3
+
+import (
+	"context"
+
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/apprclient"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/test-operator/pkg/cluster"
+	"github.com/giantswarm/test-operator/pkg/v3/guestcluster"
+	"github.com/giantswarm/test-operator/pkg/v3/resource/chart"
+	"github.com/giantswarm/test-operator/pkg/v3/resource/encryptionkey"
+	"github.com/giantswarm/test-operator/service/controller/aws/v3/key"
+	"github.com/giantswarm/test-operator/service/controller/aws/v3/resource/awsconfig"
+)
+
+const (
+	// ResourceRetries presents number of retries for failed Resource
+	// operation before giving up.
+	ResourceRetries uint64 = 3
+)
+
+// ResourceSetConfig contains necessary dependencies and settings for
+// AWSClusterConfig controller ResourceSet configuration.
+type ResourceSetConfig struct {
+	ApprClient        *apprclient.Client
+	BaseClusterConfig *cluster.Config
+	CertSearcher      certs.Interface
+	Fs                afero.Fs
+	G8sClient         versioned.Interface
+	K8sClient         kubernetes.Interface
+	Logger            micrologger.Logger
+
+	HandledVersionBundles []string
+	ProjectName           string
+}
+
+// NewResourceSet returns a configured AWSClusterConfig controller ResourceSet.
+func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+
+	var encryptionKeyResource controller.Resource
+	{
+		c := encryptionkey.Config{
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+		}
+
+		ops, err := encryptionkey.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		encryptionKeyResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var awsConfigResource controller.Resource
+	{
+		c := awsconfig.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := awsconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		awsConfigResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var guestClusterService *guestcluster.Service
+	{
+		c := guestcluster.Config{
+			CertsSearcher: config.CertSearcher,
+			Logger:        config.Logger,
+		}
+
+		guestClusterService, err = guestcluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var chartResource controller.Resource
+	{
+		c := chart.Config{
+			ApprClient:               config.ApprClient,
+			BaseClusterConfig:        *config.BaseClusterConfig,
+			Fs:                       config.Fs,
+			G8sClient:                config.G8sClient,
+			Guest:                    guestClusterService,
+			K8sClient:                config.K8sClient,
+			Logger:                   config.Logger,
+			ProjectName:              config.ProjectName,
+			ToClusterGuestConfigFunc: toClusterGuestConfig,
+		}
+
+		ops, err := chart.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		chartResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		// Put encryptionKeyResource first because it executes faster than
+		// awsConfigResource and could introduce dependency during cluster
+		// creation.
+		encryptionKeyResource,
+		awsConfigResource,
+		chartResource,
+	}
+
+	// Wrap resources with retry and metrics.
+	{
+		retryWrapConfig := retryresource.WrapConfig{}
+
+		retryWrapConfig.BackOffFactory = func() backoff.BackOff { return backoff.WithMaxTries(backoff.NewExponentialBackOff(), ResourceRetries) }
+		retryWrapConfig.Logger = config.Logger
+
+		resources, err = retryresource.Wrap(resources, retryWrapConfig)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		metricsWrapConfig := metricsresource.WrapConfig{}
+
+		metricsWrapConfig.Name = config.ProjectName
+
+		resources, err = metricsresource.Wrap(resources, metricsWrapConfig)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		return ctx, nil
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		awsClusterConfig, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(awsClusterConfig) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}
+
+func toClusterGuestConfig(obj interface{}) (v1alpha1.ClusterGuestConfig, error) {
+	awsClusterConfig, err := key.ToCustomObject(obj)
+	if err != nil {
+		return v1alpha1.ClusterGuestConfig{}, microerror.Mask(err)
+	}
+
+	return key.ClusterGuestConfig(awsClusterConfig), nil
+}
+
+func toCRUDResource(logger micrologger.Logger, ops controller.CRUDResourceOps) (*controller.CRUDResource, error) {
+	c := controller.CRUDResourceConfig{
+		Logger: logger,
+		Ops:    ops,
+	}
+
+	r, err := controller.NewCRUDResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/aws/v4/version_bundle.go
+++ b/service/controller/aws/v4/version_bundle.go
@@ -1,0 +1,27 @@
+package v3
+
+import (
+	"time"
+
+	"github.com/giantswarm/versionbundle"
+)
+
+func VersionBundle() versionbundle.Bundle {
+	return versionbundle.Bundle{
+		Changelogs: []versionbundle.Changelog{
+			{
+				Component:   "test-operator",
+				Description: "-",
+				Kind:        versionbundle.KindChanged,
+			},
+		},
+		Components:   []versionbundle.Component{},
+		Dependencies: []versionbundle.Dependency{},
+		Deprecated:   false,
+		Name:         "test-operator",
+		Provider:     "aws",
+		Time:         time.Date(2018, time.April, 26, 12, 00, 0, 0, time.UTC),
+		Version:      "0.3.0",
+		WIP:          true,
+	}
+}


### PR DESCRIPTION
This PR got created by `opsctl` in order to automate the creation of a new WIP version bundle. This specific PR is to copy the latest resource package only. FYI @giantswarm/sig-operator @giantswarm/sig-customer @giantswarm/sre.