### PR TITLE
opsctl: copy kvm/v2 to kvm/v3

### DIFF
--- a/service/controller/kvm/v3/error.go
+++ b/service/controller/kvm/v3/error.go
@@ -1,4 +1,4 @@
-package v3
+package v2
 
 import "github.com/giantswarm/microerror"
 

--- a/service/controller/kvm/v3/resource_set.go
+++ b/service/controller/kvm/v3/resource_set.go
@@ -1,4 +1,4 @@
-package v3
+package v2
 
 import (
 	"context"
@@ -17,11 +17,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/test-operator/pkg/cluster"
-	"github.com/giantswarm/test-operator/pkg/v3/guestcluster"
-	"github.com/giantswarm/test-operator/pkg/v3/resource/chart"
-	"github.com/giantswarm/test-operator/pkg/v3/resource/encryptionkey"
-	"github.com/giantswarm/test-operator/service/controller/kvm/v3/key"
-	"github.com/giantswarm/test-operator/service/controller/kvm/v3/resource/kvmconfig"
+	"github.com/giantswarm/test-operator/pkg/v2/guestcluster"
+	"github.com/giantswarm/test-operator/pkg/v2/resource/chart"
+	"github.com/giantswarm/test-operator/pkg/v2/resource/encryptionkey"
+	"github.com/giantswarm/test-operator/service/controller/kvm/v2/key"
+	"github.com/giantswarm/test-operator/service/controller/kvm/v2/resource/kvmconfig"
 )
 
 const (

--- a/service/controller/kvm/v3/version_bundle.go
+++ b/service/controller/kvm/v3/version_bundle.go
@@ -1,4 +1,4 @@
-package v3
+package v2
 
 import (
 	"time"
@@ -25,8 +25,8 @@ func VersionBundle() versionbundle.Bundle {
 		Deprecated:   false,
 		Name:         "test-operator",
 		Provider:     "kvm",
-		Time:         time.Date(2018, time.April, 26, 12, 00, 0, 0, time.UTC),
-		Version:      "0.3.0",
-		WIP:          true,
+		Time:         time.Date(2018, time.April, 16, 12, 00, 0, 0, time.UTC),
+		Version:      "0.2.0",
+		WIP:          false,
 	}
 }


### PR DESCRIPTION
This PR got created by `opsctl` in order to automate the creation of a new WIP version bundle. This specific PR is to copy the latest resource package only. FYI @giantswarm/sig-operator @giantswarm/sig-customer @giantswarm/sre.